### PR TITLE
Associate Tasks to the User

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dist
 
 # Postgres
 postgres-data
+
+# build output
+api/build

--- a/.prettierrc.yml
+++ b/.prettierrc.yml
@@ -1,0 +1,6 @@
+bracketSameLine: true
+jsxSingleQuote: true
+semi: false
+printWidth: 100
+proseWrap: always
+singleQuote: true

--- a/api/src/models/task.ts
+++ b/api/src/models/task.ts
@@ -1,12 +1,13 @@
 import { DataTypes, ModelDefined, Optional } from 'sequelize'
 import sequelize from '../sequelize'
-// import User from './user'
+import User from './user'
 
 export type Task = {
   id: string
   createdAt: Date
   updatedAt: Date
   title: string
+  userId: string
   description?: string
 }
 
@@ -17,7 +18,7 @@ const Task: ModelDefined<Task, TaskCreation> = sequelize.define(
   {
     id: {
       primaryKey: true,
-      type: DataTypes.STRING,
+      type: DataTypes.UUID,
       defaultValue: DataTypes.UUIDV4,
     },
     title: {
@@ -28,17 +29,15 @@ const Task: ModelDefined<Task, TaskCreation> = sequelize.define(
       type: new DataTypes.STRING(4096),
       allowNull: true,
     },
-    // Relationships
-    // userID: {
-    //   type: DataTypes.STRING,
-    //   allowNull: false,
-    //   references: {
-    //     model: User,
-    //     key: 'id',
-    //   },
-    // },
   },
   { timestamps: true }
 )
+
+User.hasMany(Task, {
+  foreignKey: {
+    name:'userId',
+    allowNull: false
+  },
+})
 
 export default Task

--- a/api/src/models/user.ts
+++ b/api/src/models/user.ts
@@ -15,7 +15,7 @@ const User: ModelDefined<User, UserCreation> = sequelize.define(
   {
     id: {
       primaryKey: true,
-      type: DataTypes.STRING,
+      type: DataTypes.UUID,
       defaultValue: DataTypes.UUIDV4,
     },
     name: {

--- a/api/src/routes/tasks/tasks.ts
+++ b/api/src/routes/tasks/tasks.ts
@@ -7,9 +7,11 @@ const tasks = Router()
 
 tasks
   .route('/')
-  .get(async (_, res) => {
+  .get(async (req, res) => {
     try {
-      const tasks = await Task.findAll()
+      const tasks = await Task.findAll({where: {
+        userId: req.query.userId as string
+      }})
       res.json(tasks)
     } catch (error) {
       handleError(res, error)

--- a/api/src/sequelize.ts
+++ b/api/src/sequelize.ts
@@ -8,7 +8,9 @@ async function authenticate() {
   try {
     await sequelize.authenticate()
     console.info('Connection has been established successfully.')
-    await sequelize.sync({ force: true })
+    // await sequelize.sync() // Create table if it doesn't exist and does nothing if it already exists
+    // await sequelize.sync({ force: true }) // Create table, dropping it first if it already existed
+    await sequelize.sync({ alter: true }) // Check the current state of the table in the database (which columns it has, what are their data types, etc), and then performs the necessary changes in the table to make it match the model.
     console.info('Database tables synced successfully.')
   } catch (error) {
     console.error('Unable to connect to the database:', error)

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "concurrently": "^9.0.1",
     "eslint": "^9.11.1",
+    "prettier": "^3.3.3",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.7.0",
     "wait-on": "^8.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       eslint:
         specifier: ^9.11.1
         version: 9.12.0
+      prettier:
+        specifier: ^3.3.3
+        version: 3.3.3
       typescript:
         specifier: ^5.5.3
         version: 5.6.3
@@ -1577,6 +1580,11 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier@3.3.3:
+    resolution: {integrity: sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -3406,6 +3414,8 @@ snapshots:
       xtend: 4.0.2
 
   prelude-ls@1.2.1: {}
+
+  prettier@3.3.3: {}
 
   prop-types@15.8.1:
     dependencies:

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,13 +1,16 @@
 <!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>To Do Challenge</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -1,7 +1,7 @@
 import './app.css'
 
 import Topbar from './components/topbar'
-import UserProvider from './global-state/user-provider'
+import { UserProvider } from './global-state/user-provider'
 import Routes from './routes'
 
 export default function App() {

--- a/ui/src/components/task-card/task-card.tsx
+++ b/ui/src/components/task-card/task-card.tsx
@@ -1,6 +1,8 @@
 import { formatDistance } from 'date-fns'
 import { Card, Icon } from 'semantic-ui-react'
 import type { Task } from '../../../../api/src/models'
+import { UserContext } from '../../global-state/user-provider'
+import { useContext } from 'react'
 
 export default function TaskCard({
   onClick,
@@ -8,8 +10,8 @@ export default function TaskCard({
 }: Task & {
   onClick?: () => void
 }) {
-  const updatedVsCreated =
-    task.createdAt === task.updatedAt ? 'Created' : 'Updated'
+  const { user } = useContext(UserContext)
+  const updatedVsCreated = task.createdAt === task.updatedAt ? 'Created' : 'Updated'
   return (
     <Card
       header={task.title}
@@ -19,10 +21,10 @@ export default function TaskCard({
       description={task.description}
       onClick={onClick}
       extra={
-        <a>
-          <Icon name="user" />
-          Gabriel Konkle
-        </a>
+        <>
+          <Icon name='user' />
+          {user?.name}
+        </>
       }
     />
   )

--- a/ui/src/components/task-modal/task-modal.tsx
+++ b/ui/src/components/task-modal/task-modal.tsx
@@ -1,5 +1,5 @@
 import { formatDistance } from 'date-fns'
-import React, { useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   Button,
   Form,
@@ -13,8 +13,13 @@ import {
   TextArea,
 } from 'semantic-ui-react'
 import type { Task, TaskCreation } from '../../../../api/src/models'
+import { User } from '../../../../api/src/models/user'
 
-const defaultState: TaskCreation = { title: '', description: '' }
+const defaultState: TaskCreation = {
+  title: '',
+  description: '',
+  userId: '',
+}
 
 export default function ModalExampleModal({
   isOpen,
@@ -22,23 +27,23 @@ export default function ModalExampleModal({
   onAdd,
   onEdit,
   task,
+  user,
 }: {
   isOpen: boolean
   close: () => void
   onAdd?: (taskCreation: TaskCreation) => void
   onEdit?: (taskCreation: Task) => void
   task?: Task
+  user?: User
 }) {
+  defaultState.userId = user?.id || ''
   const initialState = task || defaultState
-  const [taskState, setTaskState] = React.useState<Task | TaskCreation>(
-    initialState
-  )
+  const [taskState, setTaskState] = useState<Task | TaskCreation>(initialState)
   const isCreation = useMemo(() => !task, [task])
-  const updatedVsCreated =
-    task?.createdAt === task?.updatedAt ? 'Created' : 'Updated'
+  const updatedVsCreated = task?.createdAt === task?.updatedAt ? 'Created' : 'Updated'
 
   // Title editing
-  const [isEditingTitle, setIsEditingTitle] = React.useState(isCreation)
+  const [isEditingTitle, setIsEditingTitle] = useState(isCreation)
   function toggleEditingTitle() {
     setIsEditingTitle((prevState) => !prevState)
   }
@@ -47,8 +52,7 @@ export default function ModalExampleModal({
   }
 
   // Description editing
-  const [isEditingDescription, setIsEditingDescription] =
-    React.useState(isCreation)
+  const [isEditingDescription, setIsEditingDescription] = useState(isCreation)
   function toggleEditingDescription() {
     setIsEditingDescription((prevState) => !prevState)
   }
@@ -81,17 +85,15 @@ export default function ModalExampleModal({
   }, [task, isOpen, initialState, isCreation])
 
   return (
-    <Modal onClose={close} open={isOpen} dimmer="blurring">
+    <Modal onClose={close} open={isOpen} dimmer='blurring'>
       <ModalHeader>
         {isEditingTitle ? (
           <Input
-            name="title"
-            action={
-              !isCreation && { icon: 'check', onClick: toggleEditingTitle }
-            }
+            name='title'
+            action={!isCreation && { icon: 'check', onClick: toggleEditingTitle }}
             onChange={changeTitle}
             value={taskState.title}
-            placeholder="Title..."
+            placeholder='Title...'
           />
         ) : (
           <>
@@ -100,7 +102,7 @@ export default function ModalExampleModal({
               style={{ marginLeft: '1rem' }}
               circular
               basic
-              icon="edit"
+              icon='edit'
               onClick={toggleEditingTitle}
             />
           </>
@@ -108,14 +110,14 @@ export default function ModalExampleModal({
       </ModalHeader>
       <ModalContent>
         <ModalDescription>
-          <Header as="h4">Description</Header>
+          <Header as='h4'>Description {user?.name}</Header>
           {isEditingDescription ? (
             <Form>
               <div style={{ display: 'flex', alignItems: 'center' }}>
                 <TextArea
-                  name="description"
+                  name='description'
                   value={taskState.description}
-                  placeholder="Description..."
+                  placeholder='Description...'
                   onChange={changeDescription}
                 />
                 {!isCreation && (
@@ -123,7 +125,7 @@ export default function ModalExampleModal({
                     style={{ marginLeft: '1rem' }}
                     circular
                     basic
-                    icon="check"
+                    icon='check'
                     onClick={toggleEditingDescription}
                   />
                 )}
@@ -136,7 +138,7 @@ export default function ModalExampleModal({
                 style={{ marginLeft: '1rem' }}
                 circular
                 basic
-                icon="edit"
+                icon='edit'
                 onClick={toggleEditingDescription}
               />
             </>

--- a/ui/src/components/topbar/topbar.tsx
+++ b/ui/src/components/topbar/topbar.tsx
@@ -1,13 +1,32 @@
+import { useContext } from 'react'
+import { UserContext } from '../../global-state/user-provider'
+import { Button } from 'semantic-ui-react'
+
 export default function Topbar() {
+  const { user, setUser } = useContext(UserContext)
+
+  const logout = () => {
+    setUser(null)
+    window.location.href = '/'
+  }
+
+  const title = user ? `${user.name}'s To Do List` : 'To Do List'
+
   return (
     <div
       style={{
-        background: 'rgb(63,74,99)',
+        background: 'rgb(40, 97, 227)',
         padding: '1rem',
         color: 'white',
-      }}
-    >
-      <h1 style={{ fontSize: '20px' }}>To Do Challenge</h1>
+      }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1 style={{ fontSize: '20px', margin: '0' }}>{title}</h1>
+        {user ? (
+          <Button onClick={logout} inverted={true}>
+            Log out
+          </Button>
+        ) : null}
+      </div>
     </div>
   )
 }

--- a/ui/src/global-state/user-provider.tsx
+++ b/ui/src/global-state/user-provider.tsx
@@ -1,16 +1,33 @@
-import { createContext, Dispatch, useState, type ReactNode } from 'react'
+import { createContext, useState, ReactNode, useEffect } from 'react'
 import { User } from '../../../api/src/models/user'
 
-export const UserContext = createContext<{
+interface UserContextType {
   user: User | null
-  setUser: Dispatch<User | null>
-}>({ user: null, setUser: () => null })
+  setUser: (user: User | null) => void
+}
 
-export default function UserProvider({ children }: { children: ReactNode }) {
+export const UserContext = createContext<UserContextType>({
+  user: null,
+  setUser: () => {},
+})
+
+export const UserProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null)
-  return (
-    <UserContext.Provider value={{ user, setUser }}>
-      {children}
-    </UserContext.Provider>
-  )
+
+  useEffect(() => {
+    const storedUser = sessionStorage.getItem('user')
+    if (storedUser) {
+      setUser(JSON.parse(storedUser))
+    }
+  }, [])
+
+  useEffect(() => {
+    if (user) {
+      sessionStorage.setItem('user', JSON.stringify(user))
+    } else {
+      sessionStorage.removeItem('user')
+    }
+  }, [user])
+
+  return <UserContext.Provider value={{ user, setUser }}>{children}</UserContext.Provider>
 }

--- a/ui/src/routes/login/login.tsx
+++ b/ui/src/routes/login/login.tsx
@@ -45,12 +45,7 @@ export default function Login() {
     <>
       <Header>What's your name?</Header>
       <Form style={{ maxWidth: '400px' }}>
-        <FormField
-          control={Input}
-          label="Name"
-          placeholder="Name"
-          onChange={updateUserName}
-        />
+        <FormField control={Input} label='Name' placeholder='Name' onChange={updateUserName} />
         <Button onClick={createOrFindUser}>Continue</Button>
       </Form>
     </>

--- a/ui/src/routes/tasks/tasks.tsx
+++ b/ui/src/routes/tasks/tasks.tsx
@@ -1,11 +1,13 @@
-import { useState } from 'react'
+import { useContext, useState } from 'react'
 import { Button } from 'semantic-ui-react'
 import { Task } from '../../../../api/src/models'
 import TaskCard from '../../components/task-card'
 import TaskModal from '../../components/task-modal'
 import useTasks from './use-tasks'
+import { UserContext } from '../../global-state/user-provider'
 
 export default function Tasks() {
+  const { user } = useContext(UserContext)
   const { tasks, createTask, updateTask } = useTasks()
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false)
   const [taskToEdit, setTaskToEdit] = useState<Task | undefined>()
@@ -24,6 +26,10 @@ export default function Tasks() {
     setIsModalOpen(false)
   }
 
+  if (!user) {
+    return <div>Not logged in</div>
+  }
+
   return (
     <div>
       <TaskModal
@@ -32,6 +38,7 @@ export default function Tasks() {
         onAdd={createTask}
         onEdit={updateTask}
         close={closeModal}
+        user={user}
       />
       <h1>My Tasks</h1>
       {tasks.map((task) => (

--- a/ui/src/routes/tasks/use-tasks.ts
+++ b/ui/src/routes/tasks/use-tasks.ts
@@ -1,13 +1,21 @@
 import axios from 'axios'
-import { useEffect, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import type { Task, TaskCreation } from '../../../../api/src/models'
+import { UserContext } from '../../global-state/user-provider'
 
 export default function useTasks() {
   const [tasks, setTasks] = useState<Task[]>([])
+  const { user } = useContext(UserContext)
 
   useEffect(() => {
-    axios.get('http://localhost:3000/tasks').then(({ data }) => setTasks(data))
-  }, [])
+    if (user?.id) {
+      axios
+        .get('http://localhost:3000/tasks', {
+          params: { userId: user?.id },
+        })
+        .then(({ data }) => setTasks(data))
+    }
+  }, [user?.id])
 
   async function createTask(newTask: TaskCreation) {
     const response = await axios.post('http://localhost:3000/tasks', newTask)
@@ -16,13 +24,10 @@ export default function useTasks() {
   }
 
   async function updateTask(updatedTask: Task) {
-    const response = await axios.patch(
-      `http://localhost:3000/tasks/${updatedTask.id}`,
-      updatedTask
-    )
+    const response = await axios.patch(`http://localhost:3000/tasks/${updatedTask.id}`, updatedTask)
     const task = response.data as Task
     setTasks((prevTasks) =>
-      prevTasks.map((prevTask) => (prevTask.id === task.id ? task : prevTask))
+      prevTasks.map((prevTask) => (prevTask.id === task.id ? task : prevTask)),
     )
   }
 


### PR DESCRIPTION
- Schema change: User hasMany Tasks
- Tasks find/create for current user
- Store current user in sessionStorage so page reloads don't lose user context
- Simulate logout for switching users
- Add prettier
- Use alter mode with sequelize.sync so API changes don't drop tables